### PR TITLE
Fix: Bound content pane scroll to prevent scrolling past end

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -653,7 +653,13 @@ pub async fn run() -> Result<()> {
                             }
                             2 => {
                                 // Content pane - scroll down
-                                app.content_scroll += 1;
+                                let filtered = app.get_filtered_posts();
+                                if let Some(post) = filtered.get(app.selected) {
+                                    let line_count = post.content.lines().count();
+                                    if app.content_scroll < line_count.saturating_sub(1) {
+                                        app.content_scroll += 1;
+                                    }
+                                }
                             }
                             _ => {}
                         }


### PR DESCRIPTION
## Summary

- Adds upper bound check on content pane scroll — stops at the last line of content instead of incrementing infinitely into blank space

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Manual: scroll to bottom of content pane — stops at last line, no blank space

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)