### PR TITLE
Fix: Map singular category field to categories in frontmatter

### DIFF
--- a/src/core/posts.rs
+++ b/src/core/posts.rs
@@ -52,32 +52,48 @@ fn parse_frontmatter(content: &str) -> Result<(HashMap<String, serde_json::Value
         return Ok((HashMap::new(), content.to_string()));
     }
 
-    let frontmatter: Frontmatter = serde_yaml::from_str(parts[1])
-        .context("Failed to parse YAML frontmatter")?;
+    let frontmatter: Frontmatter =
+        serde_yaml::from_str(parts[1]).context("Failed to parse YAML frontmatter")?;
 
     let body = parts[2].trim().to_string();
 
     // Convert to HashMap
     let mut fm_map = HashMap::new();
-    fm_map.insert("title".to_string(), serde_json::Value::String(frontmatter.title.clone()));
+    fm_map.insert(
+        "title".to_string(),
+        serde_json::Value::String(frontmatter.title.clone()),
+    );
 
     if let Some(date) = &frontmatter.date {
         fm_map.insert("date".to_string(), serde_json::Value::String(date.clone()));
     }
 
-    fm_map.insert("draft".to_string(), serde_json::Value::Bool(frontmatter.draft));
-    fm_map.insert("content_type".to_string(), serde_json::Value::String(frontmatter.content_type.clone()));
+    fm_map.insert(
+        "draft".to_string(),
+        serde_json::Value::Bool(frontmatter.draft),
+    );
+    fm_map.insert(
+        "content_type".to_string(),
+        serde_json::Value::String(frontmatter.content_type.clone()),
+    );
 
     if !frontmatter.categories.is_empty() {
-        let cats: Vec<serde_json::Value> = frontmatter.categories
+        let cats: Vec<serde_json::Value> = frontmatter
+            .categories
             .iter()
             .map(|c| serde_json::Value::String(c.clone()))
             .collect();
         fm_map.insert("categories".to_string(), serde_json::Value::Array(cats));
+    } else if let Some(cat) = &frontmatter.category {
+        fm_map.insert(
+            "categories".to_string(),
+            serde_json::Value::Array(vec![serde_json::Value::String(cat.clone())]),
+        );
     }
 
     if !frontmatter.tags.is_empty() {
-        let tags: Vec<serde_json::Value> = frontmatter.tags
+        let tags: Vec<serde_json::Value> = frontmatter
+            .tags
             .iter()
             .map(|t| serde_json::Value::String(t.clone()))
             .collect();


### PR DESCRIPTION
## Summary

- Posts using `category: "X"` (singular, common in Jekyll) now correctly appear in the metadata pane and search results
- Falls back to singular `category` only when `categories` array is empty — plural wins if both exist

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes
- [ ] Manual: create a post with `category: "test"` — verify it shows in metadata pane
- [ ] Manual: verify posts with `categories: [a, b]` still work unchanged

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)