### PR TITLE
Fix: Preserve YAML frontmatter formatting on save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,7 +228,7 @@ dependencies = [
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -321,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +353,19 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -403,6 +422,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +441,8 @@ checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -472,6 +499,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -492,6 +525,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "lock_api"
@@ -598,6 +637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -614,6 +663,12 @@ checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ratatui"
@@ -651,7 +706,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
  "libredox",
  "thiserror",
 ]
@@ -694,8 +749,21 @@ dependencies = [
  "bitflags",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -724,6 +792,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
 
 [[package]]
 name = "serde"
@@ -889,6 +963,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "textorium"
 version = "0.1.0"
 dependencies = [
@@ -903,6 +990,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror",
  "tokio",
  "toml",
@@ -1034,6 +1122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1060,6 +1154,24 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1104,6 +1216,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -1425,6 +1571,94 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ regex = "1.11"
 # Config and storage
 directories = "5.0"
 
+[dev-dependencies]
+tempfile = "3.14"
+
 [profile.release]
 opt-level = 3
 lto = true

--- a/src/core/posts.rs
+++ b/src/core/posts.rs
@@ -19,6 +19,10 @@ pub struct Post {
     pub tags: Vec<String>,
     pub content: String,
     pub frontmatter: HashMap<String, serde_json::Value>,
+    /// Raw YAML text between --- delimiters, preserved for lossless save
+    pub raw_frontmatter: String,
+    /// Snapshot of frontmatter at load time, used to detect changes on save
+    pub original_frontmatter: HashMap<String, serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,15 +46,20 @@ struct Frontmatter {
 }
 
 /// Parse frontmatter and body from markdown content
-fn parse_frontmatter(content: &str) -> Result<(HashMap<String, serde_json::Value>, String)> {
+/// Returns (parsed HashMap, body text, raw YAML text between --- delimiters)
+fn parse_frontmatter(
+    content: &str,
+) -> Result<(HashMap<String, serde_json::Value>, String, String)> {
     if !content.starts_with("---") {
-        return Ok((HashMap::new(), content.to_string()));
+        return Ok((HashMap::new(), content.to_string(), String::new()));
     }
 
     let parts: Vec<&str> = content.splitn(3, "---").collect();
     if parts.len() < 3 {
-        return Ok((HashMap::new(), content.to_string()));
+        return Ok((HashMap::new(), content.to_string(), String::new()));
     }
+
+    let raw_yaml = parts[1].to_string();
 
     let frontmatter: Frontmatter =
         serde_yaml::from_str(parts[1]).context("Failed to parse YAML frontmatter")?;
@@ -105,7 +114,7 @@ fn parse_frontmatter(content: &str) -> Result<(HashMap<String, serde_json::Value
         fm_map.insert(key, value);
     }
 
-    Ok((fm_map, body))
+    Ok((fm_map, body, raw_yaml))
 }
 
 /// Read a single post from a file
@@ -113,7 +122,7 @@ pub fn read_post(path: &Path) -> Result<Post> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read post: {}", path.display()))?;
 
-    let (frontmatter, body) = parse_frontmatter(&content)?;
+    let (frontmatter, body, raw_yaml) = parse_frontmatter(&content)?;
 
     // Extract fields
     let title = frontmatter
@@ -177,7 +186,9 @@ pub fn read_post(path: &Path) -> Result<Post> {
         categories,
         tags,
         content: body,
+        original_frontmatter: frontmatter.clone(),
         frontmatter,
+        raw_frontmatter: raw_yaml,
     })
 }
 
@@ -220,21 +231,271 @@ pub fn scan_posts(config: &Config) -> Result<Vec<Post>> {
     Ok(posts)
 }
 
-/// Save a post back to disk
+/// Serialize a serde_json::Value as inline YAML suitable for frontmatter
+fn value_to_yaml_inline(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => {
+            // Quote strings that contain special YAML characters
+            if s.contains(':')
+                || s.contains('#')
+                || s.contains('[')
+                || s.contains(']')
+                || s.contains('{')
+                || s.contains('}')
+                || s.contains(',')
+                || s.contains('&')
+                || s.contains('*')
+                || s.contains('!')
+                || s.contains('|')
+                || s.contains('>')
+                || s.contains('\'')
+                || s.contains('\n')
+                || s.starts_with(' ')
+                || s.ends_with(' ')
+            {
+                format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\""))
+            } else {
+                s.clone()
+            }
+        }
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(value_to_yaml_inline).collect();
+            format!("[{}]", items.join(", "))
+        }
+        serde_json::Value::Object(_) | serde_json::Value::Null => {
+            // Fall back to serde_yaml for complex types
+            serde_yaml::to_string(value)
+                .unwrap_or_default()
+                .trim()
+                .to_string()
+        }
+    }
+}
+
+/// Find the line range for a top-level YAML key in raw frontmatter lines.
+/// Returns (start_index, end_index_exclusive) or None if not found.
+fn find_key_lines(lines: &[&str], key: &str) -> Option<(usize, usize)> {
+    let prefix = format!("{}:", key);
+    let start = lines.iter().position(|line| {
+        let trimmed = line.trim();
+        trimmed == prefix || trimmed.starts_with(&format!("{}: ", key))
+    })?;
+
+    // Find end: next top-level key or end of lines
+    let end = lines[start + 1..]
+        .iter()
+        .position(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty()
+                && !line.starts_with(' ')
+                && !line.starts_with('\t')
+                && !trimmed.starts_with('-')
+        })
+        .map(|pos| start + 1 + pos)
+        .unwrap_or(lines.len());
+
+    Some((start, end))
+}
+
+/// Save a post back to disk, preserving original frontmatter formatting where possible
 pub fn save_post(post: &Post) -> Result<()> {
-    // Reconstruct frontmatter
-    let mut fm_lines = vec!["---".to_string()];
+    // If frontmatter is unchanged, write back the original file exactly
+    if post.frontmatter == post.original_frontmatter {
+        let full_content = format!("---{}---\n\n{}\n", post.raw_frontmatter, post.content);
+        fs::write(&post.path, full_content)
+            .with_context(|| format!("Failed to write post: {}", post.path.display()))?;
+        return Ok(());
+    }
 
-    // Serialize frontmatter map as YAML
-    let yaml_str = serde_yaml::to_string(&post.frontmatter)?;
-    fm_lines.push(yaml_str.trim().to_string());
-    fm_lines.push("---".to_string());
+    // Frontmatter was modified — patch the raw YAML
+    let raw_lines: Vec<&str> = post.raw_frontmatter.lines().collect();
+    let mut result_lines: Vec<String> = Vec::new();
+    let mut processed_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    // Combine with content
-    let full_content = format!("{}\n\n{}", fm_lines.join("\n"), post.content);
+    // Process existing lines, replacing modified values and skipping deleted keys
+    let mut i = 0;
+    while i < raw_lines.len() {
+        let line = raw_lines[i];
+        let trimmed = line.trim();
+
+        // Check if this is a top-level key line
+        if !trimmed.is_empty()
+            && !line.starts_with(' ')
+            && !line.starts_with('\t')
+            && !trimmed.starts_with('-')
+        {
+            if let Some(colon_pos) = trimmed.find(':') {
+                let key = trimmed[..colon_pos].to_string();
+
+                if let Some((start, end)) = find_key_lines(&raw_lines, &key) {
+                    if start == i {
+                        processed_keys.insert(key.clone());
+
+                        if let Some(new_value) = post.frontmatter.get(&key) {
+                            // Key still exists — check if value changed
+                            let original_value = post.original_frontmatter.get(&key);
+                            if original_value == Some(new_value) {
+                                // Unchanged — keep original lines
+                                for line in &raw_lines[start..end] {
+                                    result_lines.push(line.to_string());
+                                }
+                            } else {
+                                // Changed — write new value inline
+                                result_lines.push(format!(
+                                    "{}: {}",
+                                    key,
+                                    value_to_yaml_inline(new_value)
+                                ));
+                            }
+                            i = end;
+                            continue;
+                        } else {
+                            // Key was deleted — skip all its lines
+                            i = end;
+                            continue;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Not a top-level key or not matched — keep the line as-is
+        result_lines.push(line.to_string());
+        i += 1;
+    }
+
+    // Append any new keys that weren't in the original
+    for (key, value) in &post.frontmatter {
+        if !processed_keys.contains(key) && !post.original_frontmatter.contains_key(key) {
+            result_lines.push(format!("{}: {}", key, value_to_yaml_inline(value)));
+        }
+    }
+
+    // Reconstruct the file
+    let frontmatter_text = result_lines.join("\n");
+    let full_content = format!("---\n{}\n---\n\n{}\n", frontmatter_text, post.content);
 
     fs::write(&post.path, full_content)
         .with_context(|| format!("Failed to write post: {}", post.path.display()))?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn create_temp_post(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[test]
+    fn test_save_unchanged_post_is_byte_identical() {
+        let original = "---\ntitle: My post\ndate: 2025-01-15\ndraft: false\ntags: [rust, tui]\ncategories: [dev]\n---\n\nHello world.\n";
+        let f = create_temp_post(original);
+        let post = read_post(f.path()).unwrap();
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert_eq!(
+            saved, original,
+            "Unchanged post should be byte-identical after save"
+        );
+    }
+
+    #[test]
+    fn test_save_preserves_field_order_on_edit() {
+        let original = "---\ntitle: Original title\ndate: 2025-01-15\ndraft: true\ntags: [a, b]\n---\n\nBody text.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        // Change the title
+        post.frontmatter.insert(
+            "title".to_string(),
+            serde_json::Value::String("New title".to_string()),
+        );
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        // Title should come before date (preserved order)
+        let title_pos = saved.find("title:").unwrap();
+        let date_pos = saved.find("date:").unwrap();
+        assert!(
+            title_pos < date_pos,
+            "Field order should be preserved after edit"
+        );
+        assert!(saved.contains("title: New title"));
+        assert!(saved.contains("date: 2025-01-15"));
+    }
+
+    #[test]
+    fn test_save_only_modifies_changed_fields() {
+        let original =
+            "---\ntitle: My post\ndate: 2025-01-15T10:00:00Z\ndraft: false\n---\n\nContent here.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        // Change only draft
+        post.frontmatter
+            .insert("draft".to_string(), serde_json::Value::Bool(true));
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        // Original date format should be preserved exactly
+        assert!(
+            saved.contains("date: 2025-01-15T10:00:00Z"),
+            "Unchanged fields should be preserved exactly"
+        );
+        assert!(saved.contains("draft: true"), "Changed field should update");
+    }
+
+    #[test]
+    fn test_save_handles_added_fields() {
+        let original = "---\ntitle: My post\n---\n\nBody.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        post.frontmatter.insert(
+            "author".to_string(),
+            serde_json::Value::String("Paul".to_string()),
+        );
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert!(
+            saved.contains("author: Paul"),
+            "New field should be appended"
+        );
+        assert!(
+            saved.contains("title: My post"),
+            "Existing fields preserved"
+        );
+    }
+
+    #[test]
+    fn test_save_handles_deleted_fields() {
+        let original = "---\ntitle: My post\nauthor: Paul\ndraft: false\n---\n\nBody.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        post.frontmatter.remove("author");
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert!(!saved.contains("author"), "Deleted field should be removed");
+        assert!(saved.contains("title: My post"));
+        assert!(saved.contains("draft: false"));
+    }
 }


### PR DESCRIPTION
## Summary

- **Unchanged saves are now byte-identical** — no more field reordering, style changes, or comment loss when saving a post you didn't edit
- **Modified saves patch only changed fields** — preserves original YAML formatting, field order, and style for untouched fields
- **Handles added and deleted fields** — new fields append at the end, deleted fields are cleanly removed
- Adds `raw_frontmatter` and `original_frontmatter` to `Post` struct for change tracking
- Adds `tempfile` as a dev dependency for tests

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes — 5 new unit tests:
  - `test_save_unchanged_post_is_byte_identical`
  - `test_save_preserves_field_order_on_edit`
  - `test_save_only_modifies_changed_fields`
  - `test_save_handles_added_fields`
  - `test_save_handles_deleted_fields`

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)