### PR TITLE
Fix: Use open crate for cross-platform browser preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,6 +615,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "open"
+version = "5.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43bb73a7fa3799b198970490a51174027ba0d4ec504b03cd08caf513d40024bc"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +659,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "pin-project-lite"
@@ -985,6 +1021,7 @@ dependencies = [
  "crossterm",
  "directories",
  "glob",
+ "open",
  "ratatui",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,9 @@ regex = "1.11"
 # Config and storage
 directories = "5.0"
 
+# Cross-platform URL opening
+open = "5"
+
 [dev-dependencies]
 tempfile = "3.14"
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -808,14 +808,15 @@ pub async fn run() -> Result<()> {
                         let filtered = app.get_filtered_posts();
                         if let Some(post) = filtered.get(app.selected) {
                             if let Some(url) = app.config.preview_url(&post.path) {
-                                match Command::new("open").arg(&url).spawn() {
+                                match open::that(&url) {
                                     Ok(_) => {
                                         app.status_message =
                                             format!("✓ Opening in browser: {}", url);
                                     }
                                     Err(e) => {
                                         app.status_message =
-                                            format!("✗ Could not open browser: {}", e);
+                                            format!("✗ Could not open browser — URL: {}", url);
+                                        let _ = e; // Log suppressed; URL shown for manual copy
                                     }
                                 }
                             } else {


### PR DESCRIPTION
## Summary

- Replaces macOS-only `Command::new("open")` with the `open` crate for cross-platform URL opening (macOS, Linux, Windows)
- On failure (e.g. headless SSH), shows the URL in the status bar for manual copy instead of a generic error

## Test plan

- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (5 tests)
- [ ] Manual: press `o` on a post — browser opens on macOS

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)