### PR TITLE
Fix: content pane uses dynamic terminal height

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -458,10 +458,11 @@ fn ui(f: &mut Frame, app: &App) {
     f.render_widget(metadata, right_chunks[0]);
 
     // Content pane
+    let pane_height = right_chunks[1].height.saturating_sub(2) as usize;
     let content_text = if let Some(post) = selected_post {
         let lines: Vec<&str> = post.content.lines().collect();
         let visible_start = app.content_scroll;
-        let visible_end = (visible_start + 30).min(lines.len());
+        let visible_end = (visible_start + pane_height.max(1)).min(lines.len());
         lines[visible_start..visible_end].join("\n")
     } else {
         "No post selected".to_string()


### PR DESCRIPTION
## Summary

- Replaces hardcoded 30-line limit with actual pane height from layout (`right_chunks[1].height - 2` for borders)
- Content pane now fills available space on any terminal size

Closes #22

## Test plan

- [ ] Content pane fills available vertical space on large terminals
- [ ] Content pane doesn't overflow on small terminals
- [ ] Scrolling still works correctly
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)