### PR TITLE
Fix: filter Hugo _index.md section files from post list

### DIFF
--- a/src/core/posts.rs
+++ b/src/core/posts.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
-use super::config::Config;
+use super::config::{Config, SsgType};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Post {
@@ -217,6 +217,14 @@ pub fn scan_posts(config: &Config) -> Result<Vec<Post>> {
         let ext = path.extension().and_then(|s| s.to_str());
         if ext != Some("md") && ext != Some("markdown") {
             continue;
+        }
+
+        // Skip Hugo section index files (_index.md, index.md)
+        if config.ssg == SsgType::Hugo {
+            let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if file_name == "_index.md" || file_name == "index.md" {
+                continue;
+            }
         }
 
         // Try to read the post


### PR DESCRIPTION
## Summary

- Skips `_index.md` and `index.md` files during post scanning when SSG type is Hugo
- These are section/branch bundle metadata files, not regular posts
- Jekyll and Eleventy scanning behavior is unchanged

Closes #21

## Test plan

- [ ] Hugo site with `_index.md` files — they no longer appear in posts list
- [ ] Regular Hugo posts still scanned correctly
- [ ] Jekyll/Eleventy sites unaffected
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)