### PR TITLE
Fix: report parse errors instead of silently skipping posts

### DIFF
--- a/src/core/posts.rs
+++ b/src/core/posts.rs
@@ -192,15 +192,25 @@ pub fn read_post(path: &Path) -> Result<Post> {
     })
 }
 
+/// Result of scanning posts: successful posts and any parse errors
+pub struct ScanResult {
+    pub posts: Vec<Post>,
+    pub errors: Vec<(PathBuf, String)>,
+}
+
 /// Scan directory for all markdown posts
-pub fn scan_posts(config: &Config) -> Result<Vec<Post>> {
+pub fn scan_posts(config: &Config) -> Result<ScanResult> {
     let content_path = config.content_path();
 
     if !content_path.exists() {
-        return Ok(Vec::new());
+        return Ok(ScanResult {
+            posts: Vec::new(),
+            errors: Vec::new(),
+        });
     }
 
     let mut posts = Vec::new();
+    let mut errors = Vec::new();
 
     for entry in WalkDir::new(&content_path)
         .follow_links(true)
@@ -227,16 +237,16 @@ pub fn scan_posts(config: &Config) -> Result<Vec<Post>> {
             }
         }
 
-        // Try to read the post
-        if let Ok(post) = read_post(path) {
-            posts.push(post);
+        match read_post(path) {
+            Ok(post) => posts.push(post),
+            Err(e) => errors.push((path.to_path_buf(), format!("{:#}", e))),
         }
     }
 
     // Sort by date, newest first
     posts.sort_by(|a, b| b.date.cmp(&a.date));
 
-    Ok(posts)
+    Ok(ScanResult { posts, errors })
 }
 
 /// Serialize a serde_json::Value as inline YAML suitable for frontmatter

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -17,7 +17,7 @@ use std::process::Command;
 
 use crate::core::{
     config::Config,
-    posts::{save_post, scan_posts, Post},
+    posts::{save_post, scan_posts, Post, ScanResult},
 };
 
 pub struct App {
@@ -49,7 +49,17 @@ enum SortMode {
 impl App {
     pub fn new() -> Result<Self> {
         let config = Config::load()?;
-        let posts = scan_posts(&config)?;
+        let ScanResult { posts, errors } = scan_posts(&config)?;
+
+        let status_message = if errors.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "Loaded {} posts ({} skipped due to parse errors)",
+                posts.len(),
+                errors.len()
+            )
+        };
 
         Ok(Self {
             config,
@@ -64,7 +74,7 @@ impl App {
             drafts_only: false,
             edit_mode: false,
             edit_buffer: String::new(),
-            status_message: String::new(),
+            status_message,
             adding_field: false,
             new_field_key: String::new(),
         })
@@ -785,8 +795,17 @@ pub async fn run() -> Result<()> {
                                 app.status_message = format!("✗ Error opening editor: {}", e);
                             } else {
                                 // Reload posts after editing
-                                app.posts = scan_posts(&app.config)?;
-                                app.status_message = "✓ Reloaded after edit".to_string();
+                                let result = scan_posts(&app.config)?;
+                                let err_count = result.errors.len();
+                                app.posts = result.posts;
+                                app.status_message = if err_count > 0 {
+                                    format!(
+                                        "✓ Reloaded after edit ({} files skipped)",
+                                        err_count
+                                    )
+                                } else {
+                                    "✓ Reloaded after edit".to_string()
+                                };
                             }
                             // Redraw after returning from editor
                             terminal.clear()?;
@@ -850,7 +869,17 @@ pub async fn run() -> Result<()> {
                     KeyCode::Char('s') => app.cycle_sort(),
                     KeyCode::Char('f') => app.toggle_drafts(),
                     KeyCode::Char('r') => {
-                        app.posts = scan_posts(&app.config)?;
+                        let result = scan_posts(&app.config)?;
+                        let err_count = result.errors.len();
+                        app.posts = result.posts;
+                        app.status_message = if err_count > 0 {
+                            format!(
+                                "✓ Refreshed ({} files skipped due to parse errors)",
+                                err_count
+                            )
+                        } else {
+                            "✓ Refreshed".to_string()
+                        };
                     }
                     KeyCode::Char('o') => {
                         // Open current post in browser


### PR DESCRIPTION
## Summary

- `scan_posts` now returns `ScanResult` containing both `posts` and `errors` vectors
- Parse errors are collected with file path and error message instead of being silently dropped
- TUI status bar shows skip count on startup, refresh (`r`), and editor reload

Closes #20

## Test plan

- [ ] Malformed YAML frontmatter file → skip count shown in status bar
- [ ] Valid posts still load correctly
- [ ] Refresh (`r`) shows updated skip count
- [ ] Editor return reload shows skip count if applicable
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)