### PR TITLE
Fix: install panic hook to restore terminal on crash

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -516,6 +516,14 @@ fn ui(f: &mut Frame, app: &App) {
 }
 
 pub async fn run() -> Result<()> {
+    // Install panic hook to restore terminal on crash
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |panic_info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+        original_hook(panic_info);
+    }));
+
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();


### PR DESCRIPTION
## Summary

- Installs a panic hook before entering raw mode that restores the terminal (disable raw mode, leave alternate screen, disable mouse capture)
- Chains to the original panic hook so the panic message still prints normally
- Prevents the well-known ratatui pitfall of leaving the terminal in a broken state after a crash

Closes #19

## Test plan

- [ ] Normal exit (`q`) still works correctly
- [ ] Ctrl+C exit still works correctly
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)