### PR TITLE
Fix: Update original_frontmatter baseline after save

### DIFF
--- a/src/core/posts.rs
+++ b/src/core/posts.rs
@@ -682,4 +682,39 @@ mod tests {
         assert!(content.starts_with("---\n"));
         assert!(content.contains("---\n"));
     }
+
+    #[test]
+    fn test_multi_save_cycle_produces_correct_output() {
+        let original = "---\ntitle: My post\ndate: 2025-01-15\ndraft: true\n---\n\nBody.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        // First edit: change title
+        post.frontmatter.insert(
+            "title".to_string(),
+            serde_json::Value::String("Updated title".to_string()),
+        );
+        save_post(&post).unwrap();
+
+        // Simulate what app.rs should do: reload baseline
+        let reloaded = read_post(f.path()).unwrap();
+        post.original_frontmatter = reloaded.original_frontmatter;
+        post.raw_frontmatter = reloaded.raw_frontmatter;
+
+        // Second save with no further changes should trigger unchanged fast path
+        save_post(&post).unwrap();
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert!(saved.contains("title: Updated title"));
+        assert!(saved.contains("date: 2025-01-15"));
+
+        // Third edit: change draft
+        post.frontmatter
+            .insert("draft".to_string(), serde_json::Value::Bool(false));
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert!(saved.contains("title: Updated title"));
+        assert!(saved.contains("draft: false"));
+        assert!(saved.contains("date: 2025-01-15"));
+    }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -17,7 +17,7 @@ use std::process::Command;
 
 use crate::core::{
     config::Config,
-    posts::{save_post, scan_posts, Post, ScanResult},
+    posts::{read_post, save_post, scan_posts, Post, ScanResult},
 };
 
 pub struct App {
@@ -684,14 +684,23 @@ pub async fn run() -> Result<()> {
                     KeyCode::Char('q') => break,
                     KeyCode::Char('s') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                         // Save current post to disk
-                        let filtered = app.get_filtered_posts();
-                        if let Some(post) = filtered.get(app.selected) {
-                            // Find the actual post in posts vec
+                        let save_path = {
+                            let filtered = app.get_filtered_posts();
+                            filtered.get(app.selected).map(|p| p.path.clone())
+                        };
+                        if let Some(path) = save_path {
                             if let Some(actual_post) =
-                                app.posts.iter().find(|p| p.path == post.path)
+                                app.posts.iter_mut().find(|p| p.path == path)
                             {
                                 match save_post(actual_post) {
                                     Ok(_) => {
+                                        // Update baseline so subsequent saves use correct diff
+                                        if let Ok(reloaded) = read_post(&actual_post.path) {
+                                            actual_post.original_frontmatter =
+                                                reloaded.original_frontmatter;
+                                            actual_post.raw_frontmatter =
+                                                reloaded.raw_frontmatter;
+                                        }
                                         app.status_message =
                                             format!("✓ Saved: {}", actual_post.path.display());
                                     }


### PR DESCRIPTION
## Summary

- After Ctrl+S, re-reads the saved file to update `original_frontmatter` and `raw_frontmatter` baseline
- Fixes bug where the unchanged fast path never triggered after first edit
- Prevents incorrect frontmatter diffs in multi-edit-save sessions
- Adds `test_multi_save_cycle_produces_correct_output` test covering 3 edit-save cycles

Closes #32

## Test plan

- [x] `cargo test` — all 12 tests pass (1 new)
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)