### PR TITLE
Fix: Wrap text in content pane

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -514,7 +514,9 @@ fn ui(f: &mut Frame, app: &App) {
             Style::default()
         });
 
-    let content = Paragraph::new(content_text).block(content_block);
+    let content = Paragraph::new(content_text)
+        .block(content_block)
+        .wrap(Wrap { trim: false });
     f.render_widget(content, right_chunks[1]);
 
     // Status bar


### PR DESCRIPTION
## Summary

- Add `.wrap(Wrap { trim: false })` to content pane Paragraph widget
- Long lines now wrap to pane width instead of being clipped

Closes #39

## Test plan

- [x] `cargo test` — all 12 tests pass
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)