### PR TITLE
Fix: content pane whitespace margin at bottom

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -487,12 +487,8 @@ fn ui(f: &mut Frame, app: &App) {
     f.render_widget(metadata, right_chunks[0]);
 
     // Content pane
-    let pane_height = right_chunks[1].height.saturating_sub(2) as usize;
     let content_text = if let Some(post) = selected_post {
-        let lines: Vec<&str> = post.content.lines().collect();
-        let visible_start = app.content_scroll;
-        let visible_end = (visible_start + pane_height.max(1)).min(lines.len());
-        lines[visible_start..visible_end].join("\n")
+        post.content.clone()
     } else {
         "No post selected".to_string()
     };
@@ -516,7 +512,8 @@ fn ui(f: &mut Frame, app: &App) {
 
     let content = Paragraph::new(content_text)
         .block(content_block)
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((app.content_scroll as u16, 0));
     f.render_widget(content, right_chunks[1]);
 
     // Status bar


### PR DESCRIPTION
## Summary

- Removed manual line-slicing logic that counted source lines (mismatched with wrapped visual rows)
- Pass full content to `Paragraph` and use `.scroll((offset, 0))` so ratatui handles both wrapping and scrolling
- Eliminates the ~4-5 line blank gap at the bottom of the content pane

Closes #41

## Test plan

- [x] `cargo test` passes (12/12)
- [x] `cargo clippy` clean
- [ ] Verify content fills entire pane with no bottom gap
- [ ] Verify j/k scrolling still works in content pane
- [ ] Verify long wrapped lines are visible and scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)