### PR TITLE
Fix: light theme metadata field legibility

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -414,7 +414,7 @@ fn ui(f: &mut Frame, app: &App) {
                     "content_type" | "type" => Color::Green,
                     "date" => Color::Blue,
                     "tags" | "categories" => Color::Magenta,
-                    _ => Color::White,
+                    _ => Color::Reset,
                 };
 
                 Line::from(vec![


### PR DESCRIPTION
## Summary

- Changed default metadata field color from `Color::White` to `Color::Reset`
- Unknown frontmatter fields (e.g. `audio_url`, `description`) now use the terminal's default foreground color
- Fixes illegible text on light terminal themes while remaining visible on dark themes

Closes #40

## Test plan

- [x] `cargo test` — 12/12 passing
- [x] `cargo clippy` — clean
- [ ] Verify unknown metadata fields are readable on light terminal background
- [ ] Verify known fields (title, draft, date, etc.) retain their specific colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)