### PR TITLE
Fix: Ctrl+C unsaved changes check

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -754,7 +754,11 @@ pub async fn run() -> Result<()> {
                         }
                     }
                     KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                        break;
+                        if app.dirty_count() == 0 || app.quit_pending {
+                            break;
+                        }
+                        app.quit_pending = true;
+                        continue;
                     }
                     KeyCode::Char('j') | KeyCode::Down => {
                         match app.focused_pane {


### PR DESCRIPTION
## Summary

- Ctrl+C now uses the same dirty-check logic as `q` key
- With unsaved changes, shows quit confirmation instead of silently exiting
- Second Ctrl+C (or q) exits even with unsaved changes

Closes #46

## Test plan

- [x] `cargo test` — 12/12 passing
- [x] `cargo clippy` — clean
- [ ] Verify Ctrl+C with no unsaved changes exits immediately
- [ ] Verify Ctrl+C with unsaved changes shows confirmation message
- [ ] Verify second Ctrl+C exits despite unsaved changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)