### PR TITLE
Fix: include tags in search filter

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -101,8 +101,7 @@ impl App {
             filtered.retain(|p| p.draft);
         }
 
-        // Search: filters by title, content, and categories (case-insensitive substring match)
-        // Note: Does not search tags or other frontmatter fields
+        // Search: filters by title, content, categories, and tags (case-insensitive substring match)
         if !self.search_query.is_empty() {
             let query = self.search_query.to_lowercase();
             filtered.retain(|p| {
@@ -111,6 +110,9 @@ impl App {
                     || p.categories
                         .iter()
                         .any(|c| c.to_lowercase().contains(&query))
+                    || p.tags
+                        .iter()
+                        .any(|t| t.to_lowercase().contains(&query))
             });
         }
 


### PR DESCRIPTION
## Summary

- Added tag matching to the TUI search filter in `get_filtered_posts()`
- Search now checks title, content, categories, and tags
- Removed outdated comment noting the omission

Closes #50

## Test plan

- [x] `cargo test` — 12/12 passing
- [x] `cargo clippy` — clean
- [ ] Search for a tag name in the TUI — posts with that tag should appear
- [ ] Existing search by title/content/categories still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)