### PR TITLE
Feature: implement textorium build command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -317,9 +317,42 @@ pub async fn run(cli: Cli) -> Result<()> {
                 std::process::exit(status.code().unwrap_or(1));
             }
         }
-        Some(Commands::Build { minify: _ }) => {
-            println!("Building site...");
-            // TODO: Implement
+        Some(Commands::Build { minify }) => {
+            let config = crate::core::config::Config::load()?;
+            if config.site_path.is_empty() {
+                anyhow::bail!("No site configured. Run: textorium use <path>");
+            }
+
+            let (program, mut args): (&str, Vec<&str>) = match config.ssg {
+                crate::core::config::SsgType::Hugo => ("hugo", vec![]),
+                crate::core::config::SsgType::Jekyll => {
+                    ("bundle", vec!["exec", "jekyll", "build"])
+                }
+                crate::core::config::SsgType::Eleventy => ("npx", vec!["@11ty/eleventy"]),
+            };
+
+            if minify && config.ssg == crate::core::config::SsgType::Hugo {
+                args.push("--minify");
+            }
+
+            let ssg_name = match config.ssg {
+                crate::core::config::SsgType::Hugo => "Hugo",
+                crate::core::config::SsgType::Jekyll => "Jekyll",
+                crate::core::config::SsgType::Eleventy => "Eleventy",
+            };
+            println!("Building site with {}...", ssg_name);
+
+            let status = std::process::Command::new(program)
+                .args(&args)
+                .current_dir(&config.site_path)
+                .status()
+                .with_context(|| format!("Failed to run '{}'. Is it installed?", program))?;
+
+            if status.success() {
+                println!("✓ Build complete");
+            } else {
+                std::process::exit(status.code().unwrap_or(1));
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Implements `textorium build` to invoke the SSG-specific build command
- Hugo: `hugo [--minify]`, Jekyll: `bundle exec jekyll build`, Eleventy: `npx @11ty/eleventy`
- `--minify` flag applies to Hugo only, silently ignored for others
- Clear error message if SSG binary is missing
- Prints "Build complete" on success

Closes #49

## Test plan

- [x] `cargo test` — 12/12 passing
- [x] `cargo clippy` — clean
- [ ] `textorium build` runs Hugo build in a Hugo site
- [ ] `textorium build --minify` passes --minify to Hugo
- [ ] Running without Hugo installed shows "Is it installed?" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)