### PR TITLE
Fix: use char-safe truncation for list titles

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -178,8 +178,11 @@ pub async fn run(cli: Cli) -> Result<()> {
                             .map(|d| d.format("%Y-%m-%d").to_string())
                             .unwrap_or_else(|| "—".to_string());
                         let status = if p.draft { "draft" } else { "published" };
-                        let title = if p.title.len() > 48 {
-                            format!("{}…", &p.title[..47])
+                        let title = if p.title.chars().count() > 48 {
+                            format!(
+                                "{}…",
+                                p.title.chars().take(47).collect::<String>()
+                            )
                         } else {
                             p.title.clone()
                         };


### PR DESCRIPTION
Closes #58

## Summary
- Replace `&p.title[..47]` byte slicing with `.chars().take(47)` to prevent panic on multi-byte UTF-8 characters

## Test plan
- [x] `cargo test` — 12/12 passing
- [x] `cargo clippy` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)