### PR TITLE
Fix: Remove 5 unused Cargo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,27 +23,18 @@ clap = { version = "4.5", features = ["derive", "cargo"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1.0"
-toml = "0.8"
 
 # File system and paths
 walkdir = "2.5"
-glob = "0.3"
 
 # Date/time
 chrono = { version = "0.4", features = ["serde"] }
 
 # Error handling
 anyhow = "1.0"
-thiserror = "1.0"
 
 # Async runtime (for file watching, future features)
 tokio = { version = "1.40", features = ["full"] }
-
-# String utilities
-regex = "1.11"
-
-# Config and storage
-directories = "5.0"
 
 # Cross-platform URL opening
 open = "5"


### PR DESCRIPTION
## Summary
- Remove `regex`, `glob`, `directories`, `toml`, and `thiserror` from Cargo.toml
- None are imported anywhere in the codebase
- Reduces compile time and binary size

Closes #67

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 13 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)