### PR TITLE
Fix: Clamp selection index after refresh and editor reload

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -923,6 +923,10 @@ pub async fn run() -> Result<()> {
                                 let result = scan_posts(&app.config)?;
                                 let err_count = result.errors.len();
                                 app.posts = result.posts;
+                                let max = app.get_filtered_posts().len().saturating_sub(1);
+                                if app.selected > max {
+                                    app.set_selected(max);
+                                }
                                 app.status_message = if err_count > 0 {
                                     format!(
                                         "✓ Reloaded after edit ({} files skipped)",
@@ -997,6 +1001,10 @@ pub async fn run() -> Result<()> {
                         let result = scan_posts(&app.config)?;
                         let err_count = result.errors.len();
                         app.posts = result.posts;
+                        let max = app.get_filtered_posts().len().saturating_sub(1);
+                        if app.selected > max {
+                            app.set_selected(max);
+                        }
                         app.status_message = if err_count > 0 {
                             format!(
                                 "✓ Refreshed ({} files skipped due to parse errors)",


### PR DESCRIPTION
## Summary
- After `r` (refresh) and editor return, clamp `app.selected` to the new filtered list length
- Prevents index-out-of-bounds panic if posts were deleted externally while in editor or between refreshes

Closes #68

## Test plan
- [x] `cargo build` — clean
- [x] `cargo test` — 13 tests pass
- [ ] Manual: delete a post file externally while TUI is open, press `r` — no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)