### PR TITLE
Feature: Support TOML frontmatter (Hugo +++ delimiters)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,27 +269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories"
-version = "5.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,17 +316,6 @@ checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -367,12 +326,6 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"
@@ -530,16 +483,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
-name = "libredox"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -624,12 +567,6 @@ dependencies = [
  "libc",
  "pathdiff",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -735,46 +672,6 @@ checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
-
-[[package]]
-name = "redox_users"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror",
-]
-
-[[package]]
-name = "regex"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "rustix"
@@ -1005,7 +902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom",
  "once_cell",
  "rustix 1.1.3",
  "windows-sys 0.61.2",
@@ -1019,39 +916,15 @@ dependencies = [
  "chrono",
  "clap",
  "crossterm",
- "directories",
- "glob",
  "open",
  "ratatui",
- "regex",
  "serde",
  "serde_json",
  "serde_yaml",
  "tempfile",
- "thiserror",
  "tokio",
  "toml",
  "walkdir",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1381,15 +1254,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -1413,21 +1277,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1465,12 +1314,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -1483,12 +1326,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -1498,12 +1335,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1531,12 +1362,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -1546,12 +1371,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1567,12 +1386,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -1582,12 +1395,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -1603,9 +1410,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tokio = { version = "1.40", features = ["full"] }
 
 # Cross-platform URL opening
 open = "5"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/src/core/posts.rs
+++ b/src/core/posts.rs
@@ -8,6 +8,18 @@ use walkdir::WalkDir;
 
 use super::config::{Config, SsgType};
 
+#[derive(Debug, Clone, PartialEq)]
+pub enum FrontmatterFormat {
+    Yaml,
+    Toml,
+}
+
+impl Default for FrontmatterFormat {
+    fn default() -> Self {
+        FrontmatterFormat::Yaml
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Post {
     pub path: PathBuf,
@@ -19,10 +31,13 @@ pub struct Post {
     pub tags: Vec<String>,
     pub content: String,
     pub frontmatter: HashMap<String, serde_json::Value>,
-    /// Raw YAML text between --- delimiters, preserved for lossless save
+    /// Raw frontmatter text between delimiters, preserved for lossless save
     pub raw_frontmatter: String,
     /// Snapshot of frontmatter at load time, used to detect changes on save
     pub original_frontmatter: HashMap<String, serde_json::Value>,
+    /// Whether the frontmatter uses YAML (---) or TOML (+++) delimiters
+    #[serde(skip)]
+    pub format: FrontmatterFormat,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,18 +60,74 @@ struct Frontmatter {
     extra: HashMap<String, serde_json::Value>,
 }
 
+/// Convert a toml::Value to serde_json::Value
+fn toml_value_to_json(value: &toml::Value) -> serde_json::Value {
+    match value {
+        toml::Value::String(s) => serde_json::Value::String(s.clone()),
+        toml::Value::Integer(i) => serde_json::json!(*i),
+        toml::Value::Float(f) => serde_json::json!(*f),
+        toml::Value::Boolean(b) => serde_json::Value::Bool(*b),
+        toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
+        toml::Value::Array(arr) => {
+            serde_json::Value::Array(arr.iter().map(toml_value_to_json).collect())
+        }
+        toml::Value::Table(table) => {
+            let map: serde_json::Map<String, serde_json::Value> = table
+                .iter()
+                .map(|(k, v)| (k.clone(), toml_value_to_json(v)))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+    }
+}
+
 /// Parse frontmatter and body from markdown content
-/// Returns (parsed HashMap, body text, raw YAML text between --- delimiters)
+/// Returns (parsed HashMap, body text, raw frontmatter text, format)
 fn parse_frontmatter(
     content: &str,
-) -> Result<(HashMap<String, serde_json::Value>, String, String)> {
+) -> Result<(HashMap<String, serde_json::Value>, String, String, FrontmatterFormat)> {
+    // Detect TOML frontmatter (+++...+++)
+    if content.starts_with("+++") {
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        if parts.len() < 3 {
+            return Ok((HashMap::new(), content.to_string(), String::new(), FrontmatterFormat::Toml));
+        }
+
+        let raw_toml = parts[1].to_string();
+        let body = parts[2].trim().to_string();
+
+        let toml_table: toml::Table =
+            toml::from_str(parts[1]).context("Failed to parse TOML frontmatter")?;
+
+        // Convert TOML table to serde_json HashMap
+        let mut fm_map: HashMap<String, serde_json::Value> = HashMap::new();
+        for (key, value) in &toml_table {
+            fm_map.insert(key.clone(), toml_value_to_json(value));
+        }
+
+        // Normalize: merge singular "category" into "categories" array (same as YAML path)
+        if let Some(cat) = fm_map.remove("category") {
+            if !fm_map.contains_key("categories") {
+                if let Some(s) = cat.as_str() {
+                    fm_map.insert(
+                        "categories".to_string(),
+                        serde_json::Value::Array(vec![serde_json::Value::String(s.to_string())]),
+                    );
+                }
+            }
+        }
+
+        return Ok((fm_map, body, raw_toml, FrontmatterFormat::Toml));
+    }
+
+    // Detect YAML frontmatter (---...---)
     if !content.starts_with("---") {
-        return Ok((HashMap::new(), content.to_string(), String::new()));
+        return Ok((HashMap::new(), content.to_string(), String::new(), FrontmatterFormat::Yaml));
     }
 
     let parts: Vec<&str> = content.splitn(3, "---").collect();
     if parts.len() < 3 {
-        return Ok((HashMap::new(), content.to_string(), String::new()));
+        return Ok((HashMap::new(), content.to_string(), String::new(), FrontmatterFormat::Yaml));
     }
 
     let raw_yaml = parts[1].to_string();
@@ -116,7 +187,7 @@ fn parse_frontmatter(
         fm_map.insert(key, value);
     }
 
-    Ok((fm_map, body, raw_yaml))
+    Ok((fm_map, body, raw_yaml, FrontmatterFormat::Yaml))
 }
 
 /// Read a single post from a file
@@ -124,7 +195,7 @@ pub fn read_post(path: &Path) -> Result<Post> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("Failed to read post: {}", path.display()))?;
 
-    let (frontmatter, body, raw_yaml) = parse_frontmatter(&content)?;
+    let (frontmatter, body, raw_frontmatter_text, format) = parse_frontmatter(&content)?;
 
     // Extract fields
     let title = frontmatter
@@ -190,7 +261,8 @@ pub fn read_post(path: &Path) -> Result<Post> {
         content: body,
         original_frontmatter: frontmatter.clone(),
         frontmatter,
-        raw_frontmatter: raw_yaml,
+        raw_frontmatter: raw_frontmatter_text,
+        format,
     })
 }
 
@@ -319,20 +391,77 @@ fn find_key_lines(lines: &[&str], key: &str) -> Option<(usize, usize)> {
     Some((start, end))
 }
 
+/// Serialize a serde_json::Value as inline TOML suitable for frontmatter
+fn value_to_toml_inline(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => format!("\"{}\"", s.replace('\\', "\\\\").replace('"', "\\\"")),
+        serde_json::Value::Bool(b) => b.to_string(),
+        serde_json::Value::Number(n) => n.to_string(),
+        serde_json::Value::Array(arr) => {
+            let items: Vec<String> = arr.iter().map(value_to_toml_inline).collect();
+            format!("[{}]", items.join(", "))
+        }
+        serde_json::Value::Object(_) | serde_json::Value::Null => {
+            // For complex types, fall back to a simple representation
+            format!("\"{}\"", value)
+        }
+    }
+}
+
+/// Find the line range for a top-level TOML key in raw frontmatter lines.
+/// Returns (start_index, end_index_exclusive) or None if not found.
+fn find_toml_key_lines(lines: &[&str], key: &str) -> Option<(usize, usize)> {
+    let start = lines.iter().position(|line| {
+        let trimmed = line.trim();
+        trimmed.starts_with(key) && {
+            let rest = trimmed[key.len()..].trim_start();
+            rest.starts_with('=')
+        }
+    })?;
+
+    // TOML top-level keys are single-line (no multi-line continuation for simple values)
+    // But arrays/tables can span lines — find next top-level key or end
+    let end = lines[start + 1..]
+        .iter()
+        .position(|line| {
+            let trimmed = line.trim();
+            !trimmed.is_empty() && !trimmed.starts_with('#') && {
+                // A new top-level key: word followed by =
+                if let Some(eq_pos) = trimmed.find('=') {
+                    let before_eq = trimmed[..eq_pos].trim();
+                    !before_eq.is_empty() && before_eq.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '-')
+                } else {
+                    false
+                }
+            }
+        })
+        .map(|pos| start + 1 + pos)
+        .unwrap_or(lines.len());
+
+    Some((start, end))
+}
+
 /// Save a post back to disk, preserving original frontmatter formatting where possible
 pub fn save_post(post: &Post) -> Result<()> {
+    let (open_delim, close_delim) = match post.format {
+        FrontmatterFormat::Yaml => ("---", "---"),
+        FrontmatterFormat::Toml => ("+++", "+++"),
+    };
+
     // If frontmatter is unchanged, write back the original file exactly
     if post.frontmatter == post.original_frontmatter {
-        let full_content = format!("---{}---\n\n{}\n", post.raw_frontmatter, post.content);
+        let full_content = format!("{}{}{}\n\n{}\n", open_delim, post.raw_frontmatter, close_delim, post.content);
         fs::write(&post.path, full_content)
             .with_context(|| format!("Failed to write post: {}", post.path.display()))?;
         return Ok(());
     }
 
-    // Frontmatter was modified — patch the raw YAML
+    // Frontmatter was modified — patch the raw text
     let raw_lines: Vec<&str> = post.raw_frontmatter.lines().collect();
     let mut result_lines: Vec<String> = Vec::new();
     let mut processed_keys: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let is_toml = post.format == FrontmatterFormat::Toml;
 
     // Process existing lines, replacing modified values and skipping deleted keys
     let mut i = 0;
@@ -340,41 +469,72 @@ pub fn save_post(post: &Post) -> Result<()> {
         let line = raw_lines[i];
         let trimmed = line.trim();
 
-        // Check if this is a top-level key line
-        if !trimmed.is_empty()
-            && !line.starts_with(' ')
-            && !line.starts_with('\t')
-            && !trimmed.starts_with('-')
-        {
-            if let Some(colon_pos) = trimmed.find(':') {
-                let key = trimmed[..colon_pos].to_string();
+        if is_toml {
+            // TOML: top-level key lines use `key = value`
+            if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                if let Some(eq_pos) = trimmed.find('=') {
+                    let key = trimmed[..eq_pos].trim().to_string();
 
-                if let Some((start, end)) = find_key_lines(&raw_lines, &key) {
-                    if start == i {
-                        processed_keys.insert(key.clone());
+                    if let Some((start, end)) = find_toml_key_lines(&raw_lines, &key) {
+                        if start == i {
+                            processed_keys.insert(key.clone());
 
-                        if let Some(new_value) = post.frontmatter.get(&key) {
-                            // Key still exists — check if value changed
-                            let original_value = post.original_frontmatter.get(&key);
-                            if original_value == Some(new_value) {
-                                // Unchanged — keep original lines
-                                for line in &raw_lines[start..end] {
-                                    result_lines.push(line.to_string());
+                            if let Some(new_value) = post.frontmatter.get(&key) {
+                                let original_value = post.original_frontmatter.get(&key);
+                                if original_value == Some(new_value) {
+                                    for line in &raw_lines[start..end] {
+                                        result_lines.push(line.to_string());
+                                    }
+                                } else {
+                                    result_lines.push(format!(
+                                        "{} = {}",
+                                        key,
+                                        value_to_toml_inline(new_value)
+                                    ));
                                 }
+                                i = end;
+                                continue;
                             } else {
-                                // Changed — write new value inline
-                                result_lines.push(format!(
-                                    "{}: {}",
-                                    key,
-                                    value_to_yaml_inline(new_value)
-                                ));
+                                i = end;
+                                continue;
                             }
-                            i = end;
-                            continue;
-                        } else {
-                            // Key was deleted — skip all its lines
-                            i = end;
-                            continue;
+                        }
+                    }
+                }
+            }
+        } else {
+            // YAML: top-level key lines use `key: value`
+            if !trimmed.is_empty()
+                && !line.starts_with(' ')
+                && !line.starts_with('\t')
+                && !trimmed.starts_with('-')
+            {
+                if let Some(colon_pos) = trimmed.find(':') {
+                    let key = trimmed[..colon_pos].to_string();
+
+                    if let Some((start, end)) = find_key_lines(&raw_lines, &key) {
+                        if start == i {
+                            processed_keys.insert(key.clone());
+
+                            if let Some(new_value) = post.frontmatter.get(&key) {
+                                let original_value = post.original_frontmatter.get(&key);
+                                if original_value == Some(new_value) {
+                                    for line in &raw_lines[start..end] {
+                                        result_lines.push(line.to_string());
+                                    }
+                                } else {
+                                    result_lines.push(format!(
+                                        "{}: {}",
+                                        key,
+                                        value_to_yaml_inline(new_value)
+                                    ));
+                                }
+                                i = end;
+                                continue;
+                            } else {
+                                i = end;
+                                continue;
+                            }
                         }
                     }
                 }
@@ -389,13 +549,17 @@ pub fn save_post(post: &Post) -> Result<()> {
     // Append any new keys that weren't in the original
     for (key, value) in &post.frontmatter {
         if !processed_keys.contains(key) && !post.original_frontmatter.contains_key(key) {
-            result_lines.push(format!("{}: {}", key, value_to_yaml_inline(value)));
+            if is_toml {
+                result_lines.push(format!("{} = {}", key, value_to_toml_inline(value)));
+            } else {
+                result_lines.push(format!("{}: {}", key, value_to_yaml_inline(value)));
+            }
         }
     }
 
     // Reconstruct the file
     let frontmatter_text = result_lines.join("\n");
-    let full_content = format!("---\n{}\n---\n\n{}\n", frontmatter_text, post.content);
+    let full_content = format!("{}\n{}\n{}\n\n{}\n", open_delim, frontmatter_text, close_delim, post.content);
 
     fs::write(&post.path, full_content)
         .with_context(|| format!("Failed to write post: {}", post.path.display()))?;
@@ -786,5 +950,103 @@ mod tests {
             !saved.contains("content_type"),
             "content_type should not be injected into saved file"
         );
+    }
+
+    #[test]
+    fn test_parse_toml_frontmatter() {
+        let content = "+++\ntitle = \"My TOML Post\"\ndate = 2025-01-15T10:00:00Z\ndraft = true\ntags = [\"rust\", \"tui\"]\n+++\n\nBody text.\n";
+        let f = create_temp_post(content);
+        let post = read_post(f.path()).unwrap();
+
+        assert_eq!(post.title, "My TOML Post");
+        assert!(post.draft);
+        assert_eq!(post.tags, vec!["rust", "tui"]);
+        assert!(post.date.is_some());
+        assert_eq!(post.format, FrontmatterFormat::Toml);
+        assert_eq!(post.content, "Body text.");
+    }
+
+    #[test]
+    fn test_save_unchanged_toml_post_is_byte_identical() {
+        let original = "+++\ntitle = \"My TOML Post\"\ndate = 2025-01-15T10:00:00Z\ndraft = false\ntags = [\"rust\", \"tui\"]\n+++\n\nHello world.\n";
+        let f = create_temp_post(original);
+        let post = read_post(f.path()).unwrap();
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert_eq!(
+            saved, original,
+            "Unchanged TOML post should be byte-identical after save"
+        );
+    }
+
+    #[test]
+    fn test_save_toml_post_preserves_delimiters() {
+        let original = "+++\ntitle = \"My TOML Post\"\ndraft = true\n+++\n\nBody.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        post.frontmatter.insert(
+            "title".to_string(),
+            serde_json::Value::String("Updated TOML".to_string()),
+        );
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        assert!(
+            saved.starts_with("+++\n"),
+            "TOML post should preserve +++ delimiters, got: {}",
+            saved
+        );
+        assert!(saved.contains("+++\n\n"), "Should have closing +++ delimiter");
+        assert!(saved.contains("title = \"Updated TOML\""));
+        assert!(!saved.contains("---"), "Should not contain YAML delimiters");
+    }
+
+    #[test]
+    fn test_save_toml_preserves_field_order_on_edit() {
+        let original = "+++\ntitle = \"Original\"\ndate = 2025-01-15T10:00:00Z\ndraft = true\n+++\n\nBody.\n";
+        let f = create_temp_post(original);
+        let mut post = read_post(f.path()).unwrap();
+
+        post.frontmatter.insert(
+            "title".to_string(),
+            serde_json::Value::String("New title".to_string()),
+        );
+
+        save_post(&post).unwrap();
+
+        let saved = fs::read_to_string(f.path()).unwrap();
+        let title_pos = saved.find("title =").unwrap();
+        let date_pos = saved.find("date =").unwrap();
+        assert!(
+            title_pos < date_pos,
+            "Field order should be preserved after edit"
+        );
+    }
+
+    #[test]
+    fn test_toml_datetime_parsed_correctly() {
+        let content = "+++\ntitle = \"Date Test\"\ndate = 2025-03-15T14:30:00Z\n+++\n\nBody.\n";
+        let f = create_temp_post(content);
+        let post = read_post(f.path()).unwrap();
+
+        assert!(post.date.is_some());
+        let date = post.date.unwrap();
+        assert_eq!(date.format("%Y-%m-%d").to_string(), "2025-03-15");
+    }
+
+    #[test]
+    fn test_no_frontmatter_still_works() {
+        let content = "Just plain markdown with no frontmatter.\n";
+        let f = create_temp_post(content);
+        let post = read_post(f.path()).unwrap();
+
+        assert_eq!(post.title, "Untitled");
+        assert!(post.frontmatter.is_empty());
+        assert_eq!(post.format, FrontmatterFormat::Yaml);
+        assert!(post.content.starts_with("Just plain markdown with no frontmatter."));
     }
 }


### PR DESCRIPTION
## Summary

- Add TOML frontmatter parsing alongside YAML — posts using `+++` delimiters now load with correct title, date, draft, tags, categories
- Preserve format on save — TOML posts save as TOML, YAML posts save as YAML, with lossless round-trip for unmodified posts
- Add `FrontmatterFormat` enum to `Post` struct, `toml_value_to_json()` converter, `value_to_toml_inline()` serializer, and `find_toml_key_lines()` for TOML-aware patching

Closes #71

## Test plan

- [x] 6 new tests added (20 total, all passing)
- [x] TOML parsing extracts all frontmatter fields correctly
- [x] Unchanged TOML post saves byte-identical
- [x] Edited TOML post preserves `+++` delimiters
- [x] TOML field order preserved on edit
- [x] TOML datetime parsed correctly
- [x] No-frontmatter files still work
- [x] All existing YAML tests pass (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)