### PR TITLE
Fix: Reset content scroll and metadata cursor on post selection change

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -90,6 +90,8 @@ impl App {
     fn set_selected(&mut self, index: usize) {
         self.selected = index;
         self.table_state.select(Some(index));
+        self.content_scroll = 0;
+        self.metadata_selected = 0;
     }
 
     fn dirty_count(&self) -> usize {


### PR DESCRIPTION
## Summary

- Reset `content_scroll` to 0 and `metadata_selected` to 0 in `set_selected()` so switching posts always starts from the top of content and first metadata field

Closes #76

## Test plan

- [x] All 20 tests pass
- [ ] Manual: navigate to long post, scroll down, switch to short post — content shows from top
- [ ] Manual: select post with many fields, move cursor down, switch to post with fewer fields — cursor at first field

🤖 Generated with [Claude Code](https://claude.com/claude-code)