### PR TITLE
Fix: Sync post.date after editing date field in metadata pane

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -729,6 +729,16 @@ pub async fn run() -> Result<()> {
                                             }
                                             "tags" => actual_post.tags = parsed_list(),
                                             "categories" => actual_post.categories = parsed_list(),
+                                            "date" => {
+                                                let s = app.edit_buffer.as_str();
+                                                actual_post.date = if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s) {
+                                                    Some(dt.with_timezone(&chrono::Utc))
+                                                } else if let Ok(naive_date) = chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d") {
+                                                    naive_date.and_hms_opt(0, 0, 0).map(|dt| dt.and_utc())
+                                                } else {
+                                                    None
+                                                };
+                                            }
                                             _ => {}
                                         }
                                     }


### PR DESCRIPTION
## Summary

- Add `"date"` arm to the frontmatter edit sync block so editing a date in the metadata pane immediately updates `post.date` for display and sorting
- Uses same parse logic as `read_post()`: RFC 3339 first, then `%Y-%m-%d` fallback, `None` for invalid strings

Closes #77

## Test plan

- [x] All 20 tests pass
- [ ] Manual: edit a post's date in metadata pane, confirm date column updates immediately
- [ ] Manual: invalid date string results in empty date (no panic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)